### PR TITLE
let callback_url return configured redirect_uri if present

### DIFF
--- a/lib/omniauth/strategies/twitch.rb
+++ b/lib/omniauth/strategies/twitch.rb
@@ -54,6 +54,7 @@ module OmniAuth
       end
 
       def callback_url
+        return options[:redirect_uri] unless options[:redirect_uri].nil?
         full_host + script_name + callback_path
       end
 
@@ -61,9 +62,6 @@ module OmniAuth
         super.tap do |params|
           options[:authorize_options].each do |k|
             params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
-          end
-          if !options[:redirect_uri].nil?
-            params[:redirect_uri] = options[:redirect_uri]
           end
           params[:scope] = params[:scope] || DEFAULT_SCOPE
         end


### PR DESCRIPTION
https://github.com/WebTheoryLLC/omniauth-twitch/pull/5 only affects authorize_params, but omniauth-oauth2 also sets redirect_uri in build_access_token (https://github.com/intridea/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L89)

It uses callback_url in both spots, which you overwrite already. So the sensible thing to do here would be to just let the generated value be overriden by what we've set in redirect_uri
