### PR TITLE
Enforce that Twitch wants credentials in request body

### DIFF
--- a/lib/omniauth/strategies/twitch.rb
+++ b/lib/omniauth/strategies/twitch.rb
@@ -10,7 +10,8 @@ module OmniAuth
       option :client_options, {
         site: "https://id.twitch.tv",
         authorize_url: "/oauth2/authorize",
-        token_url: "/oauth2/token"
+        token_url: "/oauth2/token",
+        auth_scheme: :request_body
       }
 
       option :access_token_options, {


### PR DESCRIPTION
The `oauth2` gem has recently been updated with a breaking change that impacts this strategy: https://github.com/oauth-xx/oauth2/pull/312

`oauth2` now defaults to sending client_id and secret using Basic Auth headers, instead of the request body as before. Twitch expects the client_id in the body so this PR sets `auth_scheme` to `request_body`, which was the default before v2.

This fixes #20.

I would also be interested in taking over this gem.